### PR TITLE
Fix doubling image when resizing large image with transparency

### DIFF
--- a/src/cropt.ts
+++ b/src/cropt.ts
@@ -382,10 +382,10 @@ export class Cropt {
             // clear oc
             octx.clearRect(0, 0, curWidth, curHeight);
 
-            octx.drawImage(oc, 0, 0, curWidth, curHeight, 0, 0, cur.width, cur.height);
+            octx.drawImage(buffer, 0, 0, curWidth, curHeight, 0, 0, cur.width, cur.height);
         }
 
-        ctx.drawImage(buffer, 0, 0, cur.width, cur.height, 0, 0, canvas.width, canvas.height);
+        ctx.drawImage(oc, 0, 0, cur.width, cur.height, 0, 0, canvas.width, canvas.height);
         return canvas;
     }
 

--- a/src/cropt.ts
+++ b/src/cropt.ts
@@ -347,12 +347,14 @@ export class Cropt {
     #getCanvas(points: CropPoints, width: number, height: number) {
         var oc = this.#getUnscaledCanvas(points);
         var octx = oc.getContext('2d');
+        var buffer = document.createElement('canvas');
+        var bctx = buffer.getContext("2d");
         var canvas = document.createElement('canvas');
         var ctx = canvas.getContext("2d");
         canvas.width = width;
         canvas.height = height;
 
-        if (ctx === null || octx === null) {
+        if (ctx === null || octx === null || bctx === null) {
             throw new Error("Canvas context cannot be null");
         }
 
@@ -371,10 +373,19 @@ export class Cropt {
                 height: Math.floor(cur.height * 0.5)
             };
 
+            // write oc to buffer
+            buffer.width = curWidth;
+            buffer.height = curHeight;
+            bctx.clearRect(0, 0, buffer.width, buffer.height);
+            bctx.drawImage(oc, 0, 0);
+
+            // clear oc
+            octx.clearRect(0, 0, curWidth, curHeight);
+
             octx.drawImage(oc, 0, 0, curWidth, curHeight, 0, 0, cur.width, cur.height);
         }
 
-        ctx.drawImage(oc, 0, 0, cur.width, cur.height, 0, 0, canvas.width, canvas.height);
+        ctx.drawImage(buffer, 0, 0, cur.width, cur.height, 0, 0, canvas.width, canvas.height);
         return canvas;
     }
 


### PR DESCRIPTION
When resizing a transparent image that is more then twice the size of the target canvas size the image would start doubling. From the demo site:
![firefox_2024-05-01_15-59-28](https://github.com/theodorejb/cropt/assets/15321825/3d3f4f61-c6ef-4556-a604-aaed06173f98)

This PR adds a buffer for the image being resized and clears the image canvas between resize steps to fix this issue.