### PR TITLE
Fix boundary enforcement with large delta at the boundary

### DIFF
--- a/src/cropt.ts
+++ b/src/cropt.ts
@@ -435,13 +435,11 @@ export class Cropt {
         const vpRect = this.elements.viewport.getBoundingClientRect();
         const transform = Transform.parse(this.elements.preview);
 
-        if (vpRect.top > imgRect.top + deltaY && vpRect.bottom < imgRect.bottom + deltaY) {
-            transform.y = transform.y + deltaY;
-        }
+        const clampedDeltaY = Math.max(Math.min(vpRect.top - imgRect.top, deltaY), vpRect.bottom - imgRect.bottom);
+        const clampedDeltaX = Math.max(Math.min(vpRect.left - imgRect.left, deltaX), vpRect.right - imgRect.right);
 
-        if (vpRect.left > imgRect.left + deltaX && vpRect.right < imgRect.right + deltaX) {
-            transform.x = transform.x + deltaX;
-        }
+        transform.y += clampedDeltaY;
+        transform.x += clampedDeltaX;
 
         this.#updateCenterPoint(transform);
         this.#updateOverlayDebounced();


### PR DESCRIPTION
Currently, dragging the image so that the delta would move the image out of the viewport in an axis would cause cropt to ignore the drag delta in that axis, leaving a gap between the image and the viewport edges. This can be reproduced in the current demos by clicking and trying to drag the image quickly past the edges of the viewport.

This PR instead clamps to the edges.